### PR TITLE
clean dockerfile, get airline by iata code functional

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,6 @@ WORKDIR /go/src/github.com/abelgoodwin1988/iata-finder
 ADD . .
 ENV GO111MODULE=on
 RUN go build -mod=vendor -o ./iata-finder
-RUN ls -a
 
 # Build a leaner image with just the binary
 FROM alpine:latest

--- a/main.go
+++ b/main.go
@@ -87,7 +87,32 @@ func (*server) GetAirport(ctx context.Context, in *iatafinder.AirportDescriptor)
 }
 
 func (*server) GetAirportIATA(ctx context.Context, in *iatafinder.IATA) (*iatafinder.Airport, error) {
-	return &iatafinder.Airport{Iata: "success", Name: "JFK"}, nil
+	iata := in.GetIata()
+	for _, airport := range ds.Data.Airports {
+		if airport.Iata == iata {
+			ctxLogger.WithFields(logrus.Fields{
+				"Method": "GetAirportIata",
+				"Found":  true,
+			}).Debugf("\nFound Airport by IATA code:\n %s\n", airport)
+			return &iatafinder.Airport{
+				Id:                  int32(airport.ID),
+				Name:                airport.Name,
+				City:                airport.City,
+				Country:             airport.Country,
+				Iata:                airport.Iata,
+				Icao:                airport.Icao,
+				Latitude:            airport.Latitude,
+				Longitude:           airport.Longitude,
+				Altitude:            airport.Altitude,
+				Timezone:            airport.Tz,
+				DaylightSavingsTime: airport.DaylightSavingsTime,
+				Type:                airport.TypeField,
+				Source:              airport.Source,
+			}, nil
+		}
+	}
+	ctxLogger.Errorf("Failed to find %s in dataset for IATA's", iata)
+	return nil, fmt.Errorf("Failed to find %s in dataset for IATA's", iata)
 }
 
 func (*server) GetAirportICAO(ct context.Context, in *iatafinder.ICAO) (*iatafinder.Airport, error) {

--- a/pkg/dataservice/dataservice.go
+++ b/pkg/dataservice/dataservice.go
@@ -22,9 +22,9 @@ var ctxLogger = logger.CtxLogger.WithField("package", "dataservice")
 
 type data struct {
 	// wg       sync.WaitGroup
-	updated  time.Time
-	airports models.Airports
-	airlines models.Airlines
+	Updated  time.Time
+	Airports models.Airports
+	Airlines models.Airlines
 }
 
 // Dataservice exposes the methods and data gathered by
@@ -33,7 +33,7 @@ type Dataservice struct {
 	URLTargets      []string
 	DataDestination string
 	FileType        string
-	data            data
+	Data            data
 	Interval        time.Duration
 }
 
@@ -101,7 +101,7 @@ func (d *Dataservice) parseHandler() {
 			ctxLogger.WithError(err).Error("Error reading file %s", file)
 		}
 		// line = setNullValues(line, "\N")
-		d.data.airports = append(d.data.airports, models.Airport{
+		d.Data.Airports = append(d.Data.Airports, models.Airport{
 			ID:                  mustAtoi(line[0]),
 			Name:                line[1],
 			City:                line[2],
@@ -134,7 +134,7 @@ func (d *Dataservice) parseHandler() {
 			ctxLogger.WithError(err).Error("Error reading file %s", file)
 		}
 		// line = setNullValues(line, "\N")
-		d.data.airlines = append(d.data.airlines, models.Airline{
+		d.Data.Airlines = append(d.Data.Airlines, models.Airline{
 			ID:       mustAtoi(line[0]),
 			Name:     line[1],
 			Alias:    line[2],
@@ -145,23 +145,23 @@ func (d *Dataservice) parseHandler() {
 			Active:   line[7],
 		})
 	}
-	ctxLogger.WithFields(logrus.Fields{"Airports": len(d.data.airports), "Airlines": len(d.data.airlines)}).Debug("Values Read In")
+	ctxLogger.WithFields(logrus.Fields{"Airports": len(d.Data.Airports), "Airlines": len(d.Data.Airlines)}).Debug("Values Read In")
 	ctxLogger.Info("Finished Parse Handling")
 }
 
 // GetAirlines returns the dataservice current airlines
 func (d *Dataservice) GetAirlines() models.Airlines {
-	return d.data.airlines
+	return d.Data.Airlines
 }
 
 // GetAirports returns the dataservice current airports
 func (d *Dataservice) GetAirports() models.Airports {
-	return d.data.airports
+	return d.Data.Airports
 }
 
 // GetUpdate returns the dataservice current airlines
 func (d *Dataservice) GetUpdate() time.Time {
-	return d.data.updated
+	return d.Data.Updated
 }
 
 func mustAtoi(s string) int {


### PR DESCRIPTION
I just wanted to get a single RPC working. This can be tested with [Evans CLI](https://github.com/ktr0731/evans) establishing a connection while in the project root running (after having ran `make`):

```bash
evans --host 0.0.0.0 rpc/iatafinder.proto
```

and calling the GetAirportIATA service like so

```bash
call GetAirportIATA
JFK
```

or exchange JFK for any other valid airport IATA. This should work :)

Next I want to standardize the data models against the types in the iatafinder rpc code... so if possible, I would like to json marshall into an `iatafinder.Airports` struct and do away with the models dir.