### PR TITLE
Fix typo in 'go mod download'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 all: vendor dockerbuild containerup
 
 vendor:
-	@go mod downlad
+	@go mod download
 	@go mod vendor
 
 dockerbuild:


### PR DESCRIPTION
Small typo in _go mod download_ fixed.