### PR TITLE
add details about the rpc config and readme docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,9 @@ I was having trouble finding an API that easily made available airport & airline
 
 ## Install
 
+**Configs**
+Check the `./configs` directory for any `.example.toml` files, copy them and drop the `.example`. Fill out the values appropriately. Each config should have comments that explain what any non-obvious or standard values should be.
+
 To start the service, run `make` which handles the creation of the docker image and creates a container from it.
 
 ## Usage

--- a/configs/rpc.config.example.toml
+++ b/configs/rpc.config.example.toml
@@ -1,3 +1,6 @@
+# network refers to what network protocol; such as tcp or udp
 network=""
+# IP refers to the ip that the service should be listening on
 ip=""
+# The port specifies where the service should listen and for rpc is default 50051
 port=""


### PR DESCRIPTION
resolves #7 

we're adding details about how to use the config files for this repo.

As maybe an explanation to myself and anyone listening, I'd like to keep the configs for this application in a central location. I don't see the number of configs growing to an unwieldy quantity and having them centralized should make them easily discoverable and referenced.